### PR TITLE
feat: add group prediction feature

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -42,6 +42,9 @@ func AutoMigrate() error {
 		&models.Match{},
 		&models.Prediction{},
 		&models.ScoringRule{},
+		&models.Group{},
+		&models.GroupMember{},
+		&models.GroupCompetition{},
 	)
 }
 

--- a/handlers/group_handler.go
+++ b/handlers/group_handler.go
@@ -1,0 +1,393 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/liyufei916/footballPaul/models"
+	"github.com/liyufei916/footballPaul/services"
+)
+
+type GroupHandler struct {
+	groupService            *services.GroupService
+	leaderboardService      *services.GroupLeaderboardService
+}
+
+func NewGroupHandler() *GroupHandler {
+	return &GroupHandler{
+		groupService:       services.NewGroupService(),
+		leaderboardService: services.NewGroupLeaderboardService(),
+	}
+}
+
+// CreateGroup creates a new group
+// POST /api/groups
+func (h *GroupHandler) CreateGroup(c *gin.Context) {
+	userID, _ := c.Get("userID")
+
+	var req struct {
+		Name string `json:"name" binding:"required,min=1,max=50"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "组名必填，长度1-50字符"})
+		return
+	}
+
+	group, err := h.groupService.CreateGroup(req.Name, userID.(uint))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "创建组队失败"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"group":   group.ToResponse(),
+		"message": "组队创建成功",
+	})
+}
+
+// GetMyGroups returns all groups the current user belongs to
+// GET /api/groups
+func (h *GroupHandler) GetMyGroups(c *gin.Context) {
+	userID, _ := c.Get("userID")
+
+	groups, err := h.groupService.GetGroupsByUserID(userID.(uint))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "获取组队列表失败"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"groups": groups})
+}
+
+// GetGroup returns a group's details
+// GET /api/groups/:id
+func (h *GroupHandler) GetGroup(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	groupID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的组队ID"})
+		return
+	}
+
+	if !h.groupService.IsGroupMember(uint(groupID), userID.(uint)) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "你不是该组成员，无法查看"})
+		return
+	}
+
+	group, err := h.groupService.GetGroupByID(uint(groupID))
+	if err != nil {
+		if err == services.ErrGroupNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "组队不存在"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "获取组队信息失败"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"group": group.ToResponse()})
+}
+
+// JoinGroup joins a group via invite code
+// POST /api/groups/join
+func (h *GroupHandler) JoinGroup(c *gin.Context) {
+	userID, _ := c.Get("userID")
+
+	var req struct {
+		InviteCode string `json:"invite_code" binding:"required,len=6"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "邀请码必填，6位字符"})
+		return
+	}
+
+	group, err := h.groupService.JoinGroup(req.InviteCode, userID.(uint))
+	if err != nil {
+		if err == services.ErrInvalidInviteCode {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "邀请码无效"})
+			return
+		}
+		if err == services.ErrAlreadyInGroup {
+			c.JSON(http.StatusConflict, gin.H{"error": "你已经在该组中"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "加入组队失败"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "加入成功",
+		"group":   group.ToResponse(),
+	})
+}
+
+// LeaveGroup leaves a group
+// DELETE /api/groups/:id/leave
+func (h *GroupHandler) LeaveGroup(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	groupID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的组队ID"})
+		return
+	}
+
+	err = h.groupService.LeaveGroup(uint(groupID), userID.(uint))
+	if err != nil {
+		if err == services.ErrGroupNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "组队不存在"})
+			return
+		}
+		if err == services.ErrCannotLeaveAsOwner {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "组长无法离开，请先转让组长或解散该组"})
+			return
+		}
+		if err == services.ErrNotGroupMember {
+			c.JSON(http.StatusForbidden, gin.H{"error": "你不是该组成员"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "离开组队失败"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "已离开该组"})
+}
+
+// DeleteGroup deletes a group (owner only)
+// DELETE /api/groups/:id
+func (h *GroupHandler) DeleteGroup(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	groupID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的组队ID"})
+		return
+	}
+
+	err = h.groupService.DeleteGroup(uint(groupID), userID.(uint))
+	if err != nil {
+		if err == services.ErrGroupNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "组队不存在"})
+			return
+		}
+		if err == services.ErrNotGroupOwner {
+			c.JSON(http.StatusForbidden, gin.H{"error": "只有组长可以解散该组"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "解散组队失败"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "组队已解散"})
+}
+
+// GetMembers returns all members of a group
+// GET /api/groups/:id/members
+func (h *GroupHandler) GetMembers(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	groupID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的组队ID"})
+		return
+	}
+
+	if !h.groupService.IsGroupMember(uint(groupID), userID.(uint)) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "你不是该组成员"})
+		return
+	}
+
+	members, err := h.groupService.GetGroupMembers(uint(groupID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "获取成员列表失败"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"members": members})
+}
+
+// GetCompetitions returns all competitions tracked by a group
+// GET /api/groups/:id/competitions
+func (h *GroupHandler) GetCompetitions(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	groupID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的组队ID"})
+		return
+	}
+
+	if !h.groupService.IsGroupMember(uint(groupID), userID.(uint)) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "你不是该组成员"})
+		return
+	}
+
+	competitions, err := h.groupService.GetGroupCompetitions(uint(groupID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "获取赛事列表失败"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"competitions": competitions})
+}
+
+// AddCompetition adds a competition to a group
+// POST /api/groups/:id/competitions
+func (h *GroupHandler) AddCompetition(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	groupID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的组队ID"})
+		return
+	}
+
+	if !h.groupService.IsGroupAdmin(uint(groupID), userID.(uint)) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "只有管理员可以添加赛事"})
+		return
+	}
+
+	var req struct {
+		CompetitionID uint `json:"competition_id" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "competition_id 必填"})
+		return
+	}
+
+	err = h.groupService.AddCompetitionToGroup(uint(groupID), req.CompetitionID)
+	if err != nil {
+		if err == services.ErrCompetitionNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "赛事不存在"})
+			return
+		}
+		if err == services.ErrCompetitionExists {
+			c.JSON(http.StatusConflict, gin.H{"error": "该赛事已在组内"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "添加赛事失败"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"message": "赛事已添加到本组"})
+}
+
+// RemoveCompetition removes a competition from a group
+// DELETE /api/groups/:id/competitions/:competitionId
+func (h *GroupHandler) RemoveCompetition(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	groupID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的组队ID"})
+		return
+	}
+	competitionID, err := strconv.ParseUint(c.Param("competitionId"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的赛事ID"})
+		return
+	}
+
+	if !h.groupService.IsGroupAdmin(uint(groupID), userID.(uint)) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "只有管理员可以移除赛事"})
+		return
+	}
+
+	err = h.groupService.RemoveCompetitionFromGroup(uint(groupID), uint(competitionID))
+	if err != nil {
+		if err == services.ErrCompetitionNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "赛事不在该组内"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "移除赛事失败"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "赛事已从本组移除"})
+}
+
+// GetLeaderboard returns the leaderboard for a specific competition within a group
+// GET /api/groups/:id/leaderboard/:competitionId
+func (h *GroupHandler) GetLeaderboard(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	groupID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的组队ID"})
+		return
+	}
+	competitionID, err := strconv.ParseUint(c.Param("competitionId"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的赛事ID"})
+		return
+	}
+
+	limit := 50
+	if l := c.Query("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	if !h.groupService.IsGroupMember(uint(groupID), userID.(uint)) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "你不是该组成员"})
+		return
+	}
+
+	entries, err := h.leaderboardService.GetGroupLeaderboard(uint(groupID), uint(competitionID), limit)
+	if err != nil {
+		if err == services.ErrCompetitionNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "该赛事不在组内追踪列表中"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "获取排行榜失败"})
+		return
+	}
+
+	// Get competition info
+	var comp models.Competition
+	comps, _ := h.groupService.GetGroupCompetitions(uint(groupID))
+	for _, groupComp := range comps {
+		if groupComp.ID == uint(competitionID) {
+			comp = groupComp
+			break
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"competition": comp,
+		"leaderboard": entries,
+	})
+}
+
+// TransferOwnership transfers group ownership to another member
+// PUT /api/groups/:id/transfer-owner
+func (h *GroupHandler) TransferOwnership(c *gin.Context) {
+	userID, _ := c.Get("userID")
+	groupID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的组队ID"})
+		return
+	}
+
+	var req struct {
+		NewOwnerID uint `json:"new_owner_id" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "new_owner_id 必填"})
+		return
+	}
+
+	err = h.groupService.TransferOwnership(uint(groupID), userID.(uint), req.NewOwnerID)
+	if err != nil {
+		if err == services.ErrGroupNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "组队不存在"})
+			return
+		}
+		if err == services.ErrNotGroupOwner {
+			c.JSON(http.StatusForbidden, gin.H{"error": "只有组长可以转让"})
+			return
+		}
+		if err == services.ErrNotGroupMember {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "新组长必须是组成员"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "转让失败"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "组长已转让"})
+}

--- a/models/group.go
+++ b/models/group.go
@@ -1,0 +1,74 @@
+package models
+
+import (
+	"time"
+)
+
+// Group represents a prediction group
+type Group struct {
+	ID         uint      `gorm:"primaryKey" json:"id"`
+	Name       string    `gorm:"size:50;not null" json:"name"`
+	InviteCode string    `gorm:"size:6;uniqueIndex;not null" json:"invite_code"`
+	OwnerID    uint      `gorm:"not null;index" json:"owner_id"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+
+	Owner         User             `gorm:"foreignKey:OwnerID" json:"owner,omitempty"`
+	Members       []GroupMember    `gorm:"foreignKey:GroupID" json:"members,omitempty"`
+	Competitions []GroupCompetition `gorm:"foreignKey:GroupID" json:"competitions,omitempty"`
+}
+
+// GroupMember represents a user's membership in a group
+type GroupMember struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	GroupID   uint      `gorm:"not null;index;uniqueIndex:idx_group_user" json:"group_id"`
+	UserID    uint      `gorm:"not null;index;uniqueIndex:idx_group_user" json:"user_id"`
+	Role      string    `gorm:"type:text;default:'member'" json:"role"` // "admin" or "member"
+	JoinedAt  time.Time `json:"joined_at"`
+
+	Group Group `gorm:"foreignKey:GroupID" json:"-"`
+	User  User  `gorm:"foreignKey:UserID" json:"user,omitempty"`
+}
+
+// GroupCompetition represents a competition tracked by a group
+type GroupCompetition struct {
+	ID            uint      `gorm:"primaryKey" json:"id"`
+	GroupID       uint      `gorm:"not null;index;uniqueIndex:idx_group_competition" json:"group_id"`
+	CompetitionID uint      `gorm:"not null;index;uniqueIndex:idx_group_competition" json:"competition_id"`
+	CreatedAt     time.Time `json:"created_at"`
+
+	Group       Group       `gorm:"foreignKey:GroupID" json:"-"`
+	Competition Competition `gorm:"foreignKey:CompetitionID" json:"competition,omitempty"`
+}
+
+// GroupMemberResponse is the API response for a group member
+type GroupMemberResponse struct {
+	UserID   uint      `json:"user_id"`
+	Username string    `json:"username"`
+	Role     string    `json:"role"`
+	JoinedAt time.Time `json:"joined_at"`
+}
+
+// GroupResponse is the API response for a group
+type GroupResponse struct {
+	ID            uint      `json:"id"`
+	Name          string    `json:"name"`
+	InviteCode    string    `json:"invite_code,omitempty"`
+	OwnerID       uint      `json:"owner_id"`
+	MemberCount   int       `json:"member_count,omitempty"`
+	CompetitionCount int    `json:"competition_count,omitempty"`
+	Role          string    `json:"role,omitempty"`
+	JoinedAt      time.Time `json:"joined_at,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+// ToResponse converts a Group to GroupResponse
+func (g *Group) ToResponse() GroupResponse {
+	return GroupResponse{
+		ID:         g.ID,
+		Name:       g.Name,
+		InviteCode: g.InviteCode,
+		OwnerID:    g.OwnerID,
+		CreatedAt:  g.CreatedAt,
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -17,6 +17,7 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 	predictionHandler := handlers.NewPredictionHandler()
 	leaderboardHandler := handlers.NewLeaderboardHandler()
 	competitionHandler := handlers.NewCompetitionHandler()
+	groupHandler := handlers.NewGroupHandler()
 
 	api := r.Group("/api")
 	{
@@ -61,6 +62,28 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 			{
 				leaderboardAuth.GET("/my-rank", leaderboardHandler.GetUserRank)
 			}
+		}
+
+		// Group routes
+		groups := api.Group("/groups")
+		groups.Use(middleware.AuthMiddleware(cfg))
+		{
+			groups.POST("", groupHandler.CreateGroup)
+			groups.GET("", groupHandler.GetMyGroups)
+			groups.POST("/join", groupHandler.JoinGroup)
+
+			groups.GET("/:id", groupHandler.GetGroup)
+			groups.DELETE("/:id", groupHandler.DeleteGroup)
+			groups.DELETE("/:id/leave", groupHandler.LeaveGroup)
+
+			groups.GET("/:id/members", groupHandler.GetMembers)
+
+			groups.GET("/:id/competitions", groupHandler.GetCompetitions)
+			groups.POST("/:id/competitions", groupHandler.AddCompetition)
+			groups.DELETE("/:id/competitions/:competitionId", groupHandler.RemoveCompetition)
+
+			groups.GET("/:id/leaderboard/:competitionId", groupHandler.GetLeaderboard)
+			groups.PUT("/:id/transfer-owner", groupHandler.TransferOwnership)
 		}
 
 		users := api.Group("/users")

--- a/services/group_leaderboard_service.go
+++ b/services/group_leaderboard_service.go
@@ -1,0 +1,117 @@
+package services
+
+import (
+	"github.com/liyufei916/footballPaul/database"
+	"github.com/liyufei916/footballPaul/models"
+	"gorm.io/gorm"
+)
+
+type GroupLeaderboardEntry struct {
+	Rank             int   `json:"rank"`
+	UserID           uint  `json:"user_id"`
+	Username         string `json:"username"`
+	TotalPoints      int   `json:"total_points"`
+	PredictionsCount int64 `json:"predictions_count"`
+	ExactScores      int   `json:"exact_scores"`
+	CorrectWinners   int   `json:"correct_winners"`
+}
+
+type GroupLeaderboardService struct{}
+
+func NewGroupLeaderboardService() *GroupLeaderboardService {
+	return &GroupLeaderboardService{}
+}
+
+// GetGroupLeaderboard returns the leaderboard for a specific competition within a group
+func (s *GroupLeaderboardService) GetGroupLeaderboard(groupID, competitionID uint, limit int) ([]GroupLeaderboardEntry, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	// Verify the competition is tracked by this group
+	var gcCount int64
+	database.DB.Model(&models.GroupCompetition{}).
+		Where("group_id = ? AND competition_id = ?", groupID, competitionID).
+		Count(&gcCount)
+	if gcCount == 0 {
+		return nil, ErrCompetitionNotFound
+	}
+
+	var results []struct {
+		UserID           uint   `gorm:"column:user_id"`
+		Username         string `gorm:"column:username"`
+		TotalPoints      int    `gorm:"column:total_points"`
+		PredictionsCount int64  `gorm:"column:predictions_count"`
+		ExactScores      int    `gorm:"column:exact_scores"`
+		CorrectWinners   int    `gorm:"column:correct_winners"`
+	}
+
+	err := database.DB.Transaction(func(tx *gorm.DB) error {
+		return tx.Table("users u").
+			Select(`
+				u.id as user_id,
+				u.username as username,
+				COALESCE(SUM(p.points_earned), 0) as total_points,
+				COUNT(p.id) as predictions_count,
+				COUNT(CASE WHEN p.points_earned = 10 THEN 1 END) as exact_scores,
+				COUNT(CASE WHEN p.points_earned IN (5, 7) THEN 1 END) as correct_winners
+			`).
+			Joins("INNER JOIN group_members gm ON gm.user_id = u.id AND gm.group_id = ?", groupID).
+			Joins("INNER JOIN predictions p ON p.user_id = u.id").
+			Joins("INNER JOIN matches m ON m.id = p.match_id AND m.competition_id = ?", competitionID).
+			Where("p.is_scored = ?", true).
+			Group("u.id").
+			Order("total_points DESC, exact_scores DESC").
+			Limit(limit).
+			Scan(&results).Error
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]GroupLeaderboardEntry, 0, len(results))
+	for i, r := range results {
+		entries = append(entries, GroupLeaderboardEntry{
+			Rank:             i + 1,
+			UserID:           r.UserID,
+			Username:         r.Username,
+			TotalPoints:      r.TotalPoints,
+			PredictionsCount: r.PredictionsCount,
+			ExactScores:      r.ExactScores,
+			CorrectWinners:   r.CorrectWinners,
+		})
+	}
+
+	return entries, nil
+}
+
+// GetUserRankInGroup returns a specific user's rank in a group's competition leaderboard
+func (s *GroupLeaderboardService) GetUserRankInGroup(groupID, competitionID, userID uint) (*GroupLeaderboardEntry, error) {
+	entries, err := s.GetGroupLeaderboard(groupID, competitionID, 100)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range entries {
+		if e.UserID == userID {
+			return &e, nil
+		}
+	}
+
+	var username string
+	database.DB.Model(&models.User{}).Where("id = ?", userID).Pluck("username", &username)
+
+	return &GroupLeaderboardEntry{
+		Rank:             0,
+		UserID:           userID,
+		Username:         username,
+		TotalPoints:      0,
+		PredictionsCount: 0,
+		ExactScores:      0,
+		CorrectWinners:   0,
+	}, nil
+}

--- a/services/group_service.go
+++ b/services/group_service.go
@@ -1,0 +1,369 @@
+package services
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/liyufei916/footballPaul/database"
+	"github.com/liyufei916/footballPaul/models"
+	"gorm.io/gorm"
+)
+
+const (
+	inviteCodeCharset = "ABCDEFGHJKMNPQRSTUVWXYZ23456789" // exclude 0,O,1,I
+	inviteCodeLen     = 6
+)
+
+var (
+	ErrGroupNotFound      = errors.New("group not found")
+	ErrNotGroupMember     = errors.New("user is not a member of this group")
+	ErrAlreadyInGroup     = errors.New("user is already in this group")
+	ErrNotGroupOwner      = errors.New("only the owner can perform this action")
+	ErrNotGroupAdmin      = errors.New("only admins can perform this action")
+	ErrInvalidInviteCode  = errors.New("invalid invite code")
+	ErrCannotLeaveAsOwner = errors.New("owner cannot leave the group, transfer ownership or delete the group first")
+	ErrCompetitionExists  = errors.New("competition is already being tracked in this group")
+	ErrCompetitionNotFound = errors.New("competition not found in this group")
+)
+
+type GroupService struct{}
+
+func NewGroupService() *GroupService {
+	return &GroupService{}
+}
+
+// GenerateInviteCode generates a unique 6-character invite code
+func (s *GroupService) GenerateInviteCode() (string, error) {
+	result := make([]byte, inviteCodeLen)
+	charsetLen := big.NewInt(int64(len(inviteCodeCharset)))
+	for i := 0; i < inviteCodeLen; i++ {
+		n, err := rand.Int(rand.Reader, charsetLen)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate invite code: %w", err)
+		}
+		result[i] = inviteCodeCharset[n.Int64()]
+	}
+
+	code := string(result)
+
+	// Ensure uniqueness
+	var count int64
+	database.DB.Model(&models.Group{}).Where("invite_code = ?", code).Count(&count)
+	if count > 0 {
+		return s.GenerateInviteCode() // regenerate
+	}
+
+	return code, nil
+}
+
+// CreateGroup creates a new group with the given name and creator as owner
+func (s *GroupService) CreateGroup(name string, ownerID uint) (*models.Group, error) {
+	inviteCode, err := s.GenerateInviteCode()
+	if err != nil {
+		return nil, err
+	}
+
+	group := &models.Group{
+		Name:       name,
+		InviteCode: inviteCode,
+		OwnerID:    ownerID,
+	}
+
+	if err := database.DB.Create(group).Error; err != nil {
+		return nil, fmt.Errorf("failed to create group: %w", err)
+	}
+
+	// Add creator as admin member
+	member := &models.GroupMember{
+		GroupID:  group.ID,
+		UserID:   ownerID,
+		Role:     "admin",
+		JoinedAt: time.Now(),
+	}
+	if err := database.DB.Create(member).Error; err != nil {
+		return nil, fmt.Errorf("failed to add owner as member: %w", err)
+	}
+
+	return group, nil
+}
+
+// GetGroupsByUserID returns all groups a user belongs to
+func (s *GroupService) GetGroupsByUserID(userID uint) ([]models.GroupResponse, error) {
+	var members []models.GroupMember
+	if err := database.DB.Preload("Group").
+		Where("user_id = ?", userID).
+		Find(&members).Error; err != nil {
+		return nil, err
+	}
+
+	responses := make([]models.GroupResponse, 0, len(members))
+	for _, m := range members {
+		g := m.Group
+
+		// Count members and competitions
+		var memberCount int64
+		database.DB.Model(&models.GroupMember{}).Where("group_id = ?", g.ID).Count(&memberCount)
+
+		var compCount int64
+		database.DB.Model(&models.GroupCompetition{}).Where("group_id = ?", g.ID).Count(&compCount)
+
+		resp := models.GroupResponse{
+			ID:               g.ID,
+			Name:             g.Name,
+			OwnerID:          g.OwnerID,
+			MemberCount:      int(memberCount),
+			CompetitionCount: int(compCount),
+			Role:             m.Role,
+			JoinedAt:         m.JoinedAt,
+			CreatedAt:        g.CreatedAt,
+		}
+		responses = append(responses, resp)
+	}
+
+	return responses, nil
+}
+
+// GetGroupByID returns a group by its ID
+func (s *GroupService) GetGroupByID(groupID uint) (*models.Group, error) {
+	var group models.Group
+	if err := database.DB.First(&group, groupID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrGroupNotFound
+		}
+		return nil, err
+	}
+	return &group, nil
+}
+
+// GetGroupByInviteCode returns a group by its invite code
+func (s *GroupService) GetGroupByInviteCode(code string) (*models.Group, error) {
+	var group models.Group
+	if err := database.DB.Where("invite_code = ?", code).First(&group).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrInvalidInviteCode
+		}
+		return nil, err
+	}
+	return &group, nil
+}
+
+// JoinGroup adds a user to a group via invite code
+func (s *GroupService) JoinGroup(inviteCode string, userID uint) (*models.Group, error) {
+	group, err := s.GetGroupByInviteCode(inviteCode)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if already a member
+	var existing models.GroupMember
+	err = database.DB.Where("group_id = ? AND user_id = ?", group.ID, userID).First(&existing).Error
+	if err == nil {
+		return nil, ErrAlreadyInGroup
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	member := &models.GroupMember{
+		GroupID:  group.ID,
+		UserID:   userID,
+		Role:     "member",
+		JoinedAt: time.Now(),
+	}
+	if err := database.DB.Create(member).Error; err != nil {
+		return nil, fmt.Errorf("failed to join group: %w", err)
+	}
+
+	return group, nil
+}
+
+// LeaveGroup removes a user from a group
+func (s *GroupService) LeaveGroup(groupID, userID uint) error {
+	group, err := s.GetGroupByID(groupID)
+	if err != nil {
+		return err
+	}
+
+	if group.OwnerID == userID {
+		return ErrCannotLeaveAsOwner
+	}
+
+	result := database.DB.Where("group_id = ? AND user_id = ?", groupID, userID).Delete(&models.GroupMember{})
+	if result.RowsAffected == 0 {
+		return ErrNotGroupMember
+	}
+
+	return nil
+}
+
+// DeleteGroup deletes a group (only owner can do this)
+func (s *GroupService) DeleteGroup(groupID, userID uint) error {
+	group, err := s.GetGroupByID(groupID)
+	if err != nil {
+		return err
+	}
+
+	if group.OwnerID != userID {
+		return ErrNotGroupOwner
+	}
+
+	return database.DB.Transaction(func(tx *gorm.DB) error {
+		// Delete group competitions
+		if err := tx.Where("group_id = ?", groupID).Delete(&models.GroupCompetition{}).Error; err != nil {
+			return err
+		}
+		// Delete group members
+		if err := tx.Where("group_id = ?", groupID).Delete(&models.GroupMember{}).Error; err != nil {
+			return err
+		}
+		// Delete group
+		if err := tx.Delete(&models.Group{}, groupID).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// IsGroupMember checks if a user is a member of a group
+func (s *GroupService) IsGroupMember(groupID, userID uint) bool {
+	var count int64
+	database.DB.Model(&models.GroupMember{}).Where("group_id = ? AND user_id = ?", groupID, userID).Count(&count)
+	return count > 0
+}
+
+// IsGroupAdmin checks if a user is an admin of a group
+func (s *GroupService) IsGroupAdmin(groupID, userID uint) bool {
+	var count int64
+	database.DB.Model(&models.GroupMember{}).Where("group_id = ? AND user_id = ? AND role = ?", groupID, userID, "admin").Count(&count)
+	return count > 0
+}
+
+// IsGroupOwner checks if a user is the owner of a group
+func (s *GroupService) IsGroupOwner(groupID, userID uint) bool {
+	group, err := s.GetGroupByID(groupID)
+	if err != nil {
+		return false
+	}
+	return group.OwnerID == userID
+}
+
+// GetMemberRole returns the role of a user in a group
+func (s *GroupService) GetMemberRole(groupID, userID uint) (string, error) {
+	var member models.GroupMember
+	err := database.DB.Where("group_id = ? AND user_id = ?", groupID, userID).First(&member).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", ErrNotGroupMember
+		}
+		return "", err
+	}
+	return member.Role, nil
+}
+
+// GetGroupMembers returns all members of a group
+func (s *GroupService) GetGroupMembers(groupID uint) ([]models.GroupMemberResponse, error) {
+	var members []models.GroupMember
+	if err := database.DB.Preload("User").Where("group_id = ?", groupID).Find(&members).Error; err != nil {
+		return nil, err
+	}
+
+	responses := make([]models.GroupMemberResponse, 0, len(members))
+	for _, m := range members {
+		responses = append(responses, models.GroupMemberResponse{
+			UserID:   m.UserID,
+			Username: m.User.Username,
+			Role:     m.Role,
+			JoinedAt: m.JoinedAt,
+		})
+	}
+
+	return responses, nil
+}
+
+// GetGroupCompetitions returns all competitions tracked by a group
+func (s *GroupService) GetGroupCompetitions(groupID uint) ([]models.Competition, error) {
+	var groupComps []models.GroupCompetition
+	if err := database.DB.Preload("Competition").Where("group_id = ?", groupID).Find(&groupComps).Error; err != nil {
+		return nil, err
+	}
+
+	competitions := make([]models.Competition, 0, len(groupComps))
+	for _, gc := range groupComps {
+		competitions = append(competitions, gc.Competition)
+	}
+
+	return competitions, nil
+}
+
+// AddCompetitionToGroup adds a competition to a group
+func (s *GroupService) AddCompetitionToGroup(groupID, competitionID uint) error {
+	// Verify competition exists
+	var comp models.Competition
+	if err := database.DB.First(&comp, competitionID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrCompetitionNotFound
+		}
+		return err
+	}
+
+	// Check if already added
+	var existing models.GroupCompetition
+	err := database.DB.Where("group_id = ? AND competition_id = ?", groupID, competitionID).First(&existing).Error
+	if err == nil {
+		return ErrCompetitionExists
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+
+	gc := &models.GroupCompetition{
+		GroupID:       groupID,
+		CompetitionID: competitionID,
+		CreatedAt:     time.Now(),
+	}
+
+	return database.DB.Create(gc).Error
+}
+
+// RemoveCompetitionFromGroup removes a competition from a group
+func (s *GroupService) RemoveCompetitionFromGroup(groupID, competitionID uint) error {
+	result := database.DB.Where("group_id = ? AND competition_id = ?", groupID, competitionID).Delete(&models.GroupCompetition{})
+	if result.RowsAffected == 0 {
+		return ErrCompetitionNotFound
+	}
+	return result.Error
+}
+
+// TransferOwnership transfers group ownership to another member
+func (s *GroupService) TransferOwnership(groupID, currentUserID, newOwnerID uint) error {
+	group, err := s.GetGroupByID(groupID)
+	if err != nil {
+		return err
+	}
+
+	if group.OwnerID != currentUserID {
+		return ErrNotGroupOwner
+	}
+
+	// Verify new owner is a member
+	if !s.IsGroupMember(groupID, newOwnerID) {
+		return ErrNotGroupMember
+	}
+
+	return database.DB.Transaction(func(tx *gorm.DB) error {
+		// Update group owner
+		if err := tx.Model(&models.Group{}).Where("id = ?", groupID).Update("owner_id", newOwnerID).Error; err != nil {
+			return err
+		}
+		// Update roles: new owner becomes admin, old owner stays admin
+		if err := tx.Model(&models.GroupMember{}).
+			Where("group_id = ? AND user_id = ?", groupID, newOwnerID).
+			Update("role", "admin").Error; err != nil {
+			return err
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
- Add Group, GroupMember, GroupCompetition models
- Add GroupService: create/join/leave/delete group, member management
- Add GroupLeaderboardService: group-specific competition leaderboard
- Add GroupHandler: all /api/groups endpoints
- Register group routes in router
- Auto-migrate new tables