### PR TITLE
feat: add group feature frontend pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,13 @@ import MatchDetailPage from './pages/MatchDetailPage';
 import MyPredictionsPage from './pages/MyPredictionsPage';
 import LeaderboardPage from './pages/LeaderboardPage';
 import AdminPage from './pages/AdminPage';
+import MyGroupsPage from './pages/MyGroupsPage';
+import CreateGroupPage from './pages/CreateGroupPage';
+import JoinGroupPage from './pages/JoinGroupPage';
+import GroupDetailPage from './pages/GroupDetailPage';
+import GroupMembersPage from './pages/GroupMembersPage';
+import GroupLeaderboardPage from './pages/GroupLeaderboardPage';
+import AddGroupCompetitionPage from './pages/AddGroupCompetitionPage';
 
 export default function App() {
   return (
@@ -22,6 +29,8 @@ export default function App() {
             <Route path="/register" element={<RegisterPage />} />
             <Route path="/matches/:id" element={<MatchDetailPage />} />
             <Route path="/leaderboard" element={<LeaderboardPage />} />
+
+            {/* Protected Routes */}
             <Route
               path="/my-predictions"
               element={
@@ -35,6 +44,64 @@ export default function App() {
               element={
                 <ProtectedRoute adminOnly>
                   <AdminPage />
+                </ProtectedRoute>
+              }
+            />
+
+            {/* Group Routes */}
+            <Route
+              path="/groups"
+              element={
+                <ProtectedRoute>
+                  <MyGroupsPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/groups/new"
+              element={
+                <ProtectedRoute>
+                  <CreateGroupPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/groups/join"
+              element={
+                <ProtectedRoute>
+                  <JoinGroupPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/groups/:id"
+              element={
+                <ProtectedRoute>
+                  <GroupDetailPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/groups/:id/members"
+              element={
+                <ProtectedRoute>
+                  <GroupMembersPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/groups/:id/leaderboard/:competitionId"
+              element={
+                <ProtectedRoute>
+                  <GroupLeaderboardPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/groups/:id/add-competition"
+              element={
+                <ProtectedRoute>
+                  <AddGroupCompetitionPage />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/api/apiClient.js
+++ b/frontend/src/api/apiClient.js
@@ -67,3 +67,21 @@ export const getMyRank = (competitionId) => {
 
 // User APIs
 export const getProfile = () => api.get('/users/profile');
+
+// Group APIs
+export const getMyGroups = () => api.get('/groups');
+export const getGroup = (id) => api.get(`/groups/${id}`);
+export const createGroup = (data) => api.post('/groups', data);
+export const joinGroup = (inviteCode) => api.post('/groups/join', { invite_code: inviteCode });
+export const leaveGroup = (id) => api.delete(`/groups/${id}/leave`);
+export const deleteGroup = (id) => api.delete(`/groups/${id}`);
+export const getGroupMembers = (id) => api.get(`/groups/${id}/members`);
+export const getGroupCompetitions = (id) => api.get(`/groups/${id}/competitions`);
+export const addGroupCompetition = (id, competitionId) =>
+  api.post(`/groups/${id}/competitions`, { competition_id: competitionId });
+export const removeGroupCompetition = (id, competitionId) =>
+  api.delete(`/groups/${id}/competitions/${competitionId}`);
+export const getGroupLeaderboard = (groupId, competitionId, limit = 50) =>
+  api.get(`/groups/${groupId}/leaderboard/${competitionId}`, { params: { limit } });
+export const transferGroupOwnership = (id, newOwnerId) =>
+  api.put(`/groups/${id}/transfer-owner`, { new_owner_id: newOwnerId });

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { Trophy, LogOut, User, Settings } from 'lucide-react';
+import { Trophy, LogOut, User, Settings, Users } from 'lucide-react';
 
 export default function Navbar() {
   const { user, isAuthenticated, isAdmin, logout } = useAuth();
@@ -16,7 +16,7 @@ export default function Navbar() {
       <div className="max-w-7xl mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           <Link to="/" className="flex items-center gap-2">
-            <div className="w-10 h-10 pitch-gradient rounded-full flex items-center justify-center">
+            <div className="w-10 h-10 bg-pitch-600 rounded-full flex items-center justify-center">
               <Trophy className="w-6 h-6 text-white" />
             </div>
             <span className="text-xl font-bold text-white">FootballPaul</span>
@@ -43,6 +43,13 @@ export default function Navbar() {
                   className="text-slate-300 hover:text-pitch-400 transition-colors"
                 >
                   我的预测
+                </Link>
+                <Link
+                  to="/groups"
+                  className="text-slate-300 hover:text-pitch-400 transition-colors flex items-center gap-1.5"
+                >
+                  <Users className="w-4 h-4" />
+                  我的组
                 </Link>
                 {isAdmin && (
                   <Link

--- a/frontend/src/pages/AddGroupCompetitionPage.jsx
+++ b/frontend/src/pages/AddGroupCompetitionPage.jsx
@@ -1,0 +1,124 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { getCompetitions, getGroupCompetitions, addGroupCompetition } from '../api/apiClient';
+import { ArrowLeft, Trophy, Check } from 'lucide-react';
+
+export default function AddGroupCompetitionPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [allCompetitions, setAllCompetitions] = useState([]);
+  const [trackedIds, setTrackedIds] = useState(new Set());
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [selected, setSelected] = useState(new Set());
+
+  useEffect(() => {
+    fetchData();
+  }, [id]);
+
+  const fetchData = async () => {
+    setIsLoading(true);
+    try {
+      const [compsRes, trackedRes] = await Promise.all([
+        getCompetitions(),
+        getGroupCompetitions(id),
+      ]);
+      const all = compsRes.data.competitions || [];
+      const tracked = trackedRes.data.competitions || [];
+      setAllCompetitions(all);
+      setTrackedIds(new Set(tracked.map((c) => c.id)));
+    } catch (err) {
+      console.error('Failed to fetch competitions:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const toggleCompetition = (compId) => {
+    const newSelected = new Set(selected);
+    if (newSelected.has(compId)) {
+      newSelected.delete(compId);
+    } else {
+      newSelected.add(compId);
+    }
+    setSelected(newSelected);
+  };
+
+  const handleAdd = async () => {
+    if (selected.size === 0) return;
+    setIsSaving(true);
+    try {
+      for (const compId of selected) {
+        await addGroupCompetition(id, compId);
+      }
+      navigate(`/groups/${id}`);
+    } catch (err) {
+      alert(err.response?.data?.error || '添加失败');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const availableCompetitions = allCompetitions.filter((c) => !trackedIds.has(c.id));
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-8">
+      <div className="flex items-center gap-3 mb-8">
+        <Link to={`/groups/${id}`} className="text-slate-400 hover:text-white transition-colors">
+          <ArrowLeft className="w-6 h-6" />
+        </Link>
+        <h1 className="text-xl font-bold text-white">添加追踪赛事</h1>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-slate-800 rounded-xl p-4 animate-pulse">
+              <div className="h-5 bg-slate-700 rounded w-2/3"></div>
+            </div>
+          ))}
+        </div>
+      ) : availableCompetitions.length === 0 ? (
+        <div className="text-center py-16">
+          <Trophy className="w-16 h-16 text-slate-600 mx-auto mb-4" />
+          <p className="text-slate-400">所有赛事都已在追踪列表中</p>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-3 mb-6">
+            {availableCompetitions.map((comp) => (
+              <button
+                key={comp.id}
+                onClick={() => toggleCompetition(comp.id)}
+                className={`w-full flex items-center gap-3 bg-slate-800 border rounded-xl p-4 transition-colors ${
+                  selected.has(comp.id)
+                    ? 'border-blue-500 bg-blue-600/10'
+                    : 'border-slate-700 hover:border-slate-600'
+                }`}
+              >
+                <div className={`w-6 h-6 rounded-full border-2 flex items-center justify-center ${
+                  selected.has(comp.id)
+                    ? 'border-blue-500 bg-blue-500'
+                    : 'border-slate-600'
+                }`}>
+                  {selected.has(comp.id) && <Check className="w-4 h-4 text-white" />}
+                </div>
+                <div className="flex-1 text-left">
+                  <span className="font-medium text-white">{comp.name}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          <button
+            onClick={handleAdd}
+            disabled={selected.size === 0 || isSaving}
+            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-slate-700 disabled:text-slate-500 text-white font-medium py-3 rounded-lg transition-colors"
+          >
+            {isSaving ? '添加中...' : `添加 ${selected.size > 0 ? `(${selected.size})` : ''}`}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/CreateGroupPage.jsx
+++ b/frontend/src/pages/CreateGroupPage.jsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createGroup } from '../api/apiClient';
+import { ArrowLeft } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+export default function CreateGroupPage() {
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError('请输入组名');
+      return;
+    }
+    if (name.trim().length > 50) {
+      setError('组名最长50个字符');
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+    try {
+      const res = await createGroup({ name: name.trim() });
+      navigate(`/groups/${res.data.group.id}`);
+    } catch (err) {
+      setError(err.response?.data?.error || '创建失败，请重试');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-8">
+      <div className="flex items-center gap-3 mb-8">
+        <Link to="/groups" className="text-slate-400 hover:text-white transition-colors">
+          <ArrowLeft className="w-6 h-6" />
+        </Link>
+        <h1 className="text-xl font-bold text-white">创建组</h1>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div>
+          <label className="block text-slate-300 text-sm font-medium mb-2">组名</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="例如：欧冠竞猜群"
+            maxLength={50}
+            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:border-blue-500 transition-colors"
+            autoFocus
+          />
+          {error && <p className="mt-2 text-red-400 text-sm">{error}</p>}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-slate-700 text-white font-medium py-3 rounded-lg transition-colors"
+        >
+          {isLoading ? '创建中...' : '创建组'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/GroupDetailPage.jsx
+++ b/frontend/src/pages/GroupDetailPage.jsx
@@ -1,0 +1,190 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { getGroup, getGroupCompetitions, leaveGroup, deleteGroup, getMyGroups } from '../api/apiClient';
+import { Users, Trophy, ArrowLeft, Crown, Plus, Trash2, LogOut } from 'lucide-react';
+import { useAuth } from '../context/AuthContext';
+
+export default function GroupDetailPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [group, setGroup] = useState(null);
+  const [competitions, setCompetitions] = useState([]);
+  const [myGroups, setMyGroups] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [isOwner, setIsOwner] = useState(false);
+
+  useEffect(() => {
+    fetchData();
+  }, [id]);
+
+  const fetchData = async () => {
+    setIsLoading(true);
+    try {
+      const [groupRes, compsRes, myGroupsRes] = await Promise.all([
+        getGroup(id),
+        getGroupCompetitions(id),
+        getMyGroups(),
+      ]);
+      setGroup(groupRes.data.group);
+      setCompetitions(compsRes.data.competitions || []);
+      setMyGroups(myGroupsRes.data.groups || []);
+    } catch (err) {
+      console.error('Failed to fetch group:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (group && user) {
+      const membership = myGroups.find((g) => g.id === parseInt(id));
+      setIsAdmin(membership?.role === 'admin');
+      setIsOwner(group.owner_id === user.id);
+    }
+  }, [group, user, myGroups]);
+
+  const handleLeave = async () => {
+    if (!window.confirm('确定要离开该组吗？')) return;
+    try {
+      await leaveGroup(id);
+      navigate('/groups');
+    } catch (err) {
+      alert(err.response?.data?.error || '离开失败');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm('确定要解散该组吗？此操作不可恢复！')) return;
+    try {
+      await deleteGroup(id);
+      navigate('/groups');
+    } catch (err) {
+      alert(err.response?.data?.error || '解散失败');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <div className="bg-slate-800 rounded-xl p-8 animate-pulse">
+          <div className="h-8 bg-slate-700 rounded w-1/3 mb-4"></div>
+          <div className="h-4 bg-slate-700 rounded w-1/2"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!group) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-8 text-center">
+        <p className="text-slate-400">组队不存在或你无权访问</p>
+        <Link to="/groups" className="text-blue-400 hover:underline mt-4 inline-block">返回我的组</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <div className="flex items-center gap-3 mb-6">
+        <Link to="/groups" className="text-slate-400 hover:text-white transition-colors">
+          <ArrowLeft className="w-6 h-6" />
+        </Link>
+      </div>
+
+      {/* Group Header */}
+      <div className="bg-slate-800 border border-slate-700 rounded-xl p-6 mb-6">
+        <div className="flex items-center gap-4 mb-4">
+          <div className={`w-14 h-14 rounded-xl flex items-center justify-center ${isOwner ? 'bg-gold-600' : 'bg-blue-600'}`}>
+            {isOwner ? <Crown className="w-7 h-7 text-white" /> : <Users className="w-7 h-7 text-white" />}
+          </div>
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold text-white">{group.name}</h1>
+              {isOwner && <span className="text-xs bg-gold-600/20 text-gold-400 px-2 py-0.5 rounded">组长</span>}
+              {isAdmin && !isOwner && <span className="text-xs bg-blue-600/20 text-blue-400 px-2 py-0.5 rounded">管理员</span>}
+            </div>
+            <p className="text-slate-400 text-sm">邀请码：<span className="font-mono text-white">{group.invite_code}</span></p>
+          </div>
+        </div>
+
+        <div className="flex gap-3">
+          <Link
+            to={`/groups/${id}/members`}
+            className="flex-1 bg-slate-700 hover:bg-slate-600 text-white text-center py-2.5 rounded-lg transition-colors text-sm"
+          >
+            查看成员
+          </Link>
+          {isOwner && (
+            <button
+              onClick={handleDelete}
+              className="flex items-center gap-1.5 bg-red-600/20 hover:bg-red-600 text-red-400 px-4 py-2.5 rounded-lg transition-colors text-sm"
+            >
+              <Trash2 className="w-4 h-4" />
+              解散组
+            </button>
+          )}
+          {!isOwner && (
+            <button
+              onClick={handleLeave}
+              className="flex items-center gap-1.5 bg-red-600/20 hover:bg-red-600 text-red-400 px-4 py-2.5 rounded-lg transition-colors text-sm"
+            >
+              <LogOut className="w-4 h-4" />
+              离开组
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Competitions Section */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <Trophy className="w-5 h-5 text-slate-400" />
+            <h2 className="text-lg font-semibold text-white">追踪赛事</h2>
+          </div>
+          {isAdmin && (
+            <Link
+              to={`/groups/${id}/add-competition`}
+              className="flex items-center gap-1 text-blue-400 hover:text-blue-300 text-sm transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              添加赛事
+            </Link>
+          )}
+        </div>
+
+        {competitions.length === 0 ? (
+          <div className="bg-slate-800 border border-slate-700 rounded-xl p-8 text-center">
+            <Trophy className="w-12 h-12 text-slate-600 mx-auto mb-3" />
+            <p className="text-slate-400 mb-1">暂未追踪任何赛事</p>
+            {isAdmin && (
+              <Link to={`/groups/${id}/add-competition`} className="text-blue-400 hover:underline text-sm">
+                添加一个赛事
+              </Link>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {competitions.map((comp) => (
+              <div key={comp.id} className="bg-slate-800 border border-slate-700 rounded-xl p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="font-medium text-white">{comp.name}</h3>
+                  </div>
+                  <Link
+                    to={`/groups/${id}/leaderboard/${comp.id}`}
+                    className="bg-pitch-600 hover:bg-pitch-700 text-white px-4 py-1.5 rounded-lg text-sm transition-colors"
+                  >
+                    组排行榜
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/GroupLeaderboardPage.jsx
+++ b/frontend/src/pages/GroupLeaderboardPage.jsx
@@ -1,0 +1,164 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { getGroupLeaderboard, getGroup, getGroupCompetitions } from '../api/apiClient';
+import { ArrowLeft, Trophy, Medal, User } from 'lucide-react';
+import { useAuth } from '../context/AuthContext';
+
+export default function GroupLeaderboardPage() {
+  const { id, competitionId } = useParams();
+  const { user } = useAuth();
+  const [group, setGroup] = useState(null);
+  const [competition, setCompetition] = useState(null);
+  const [competitions, setCompetitions] = useState([]);
+  const [leaderboard, setLeaderboard] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedCompId, setSelectedCompId] = useState(parseInt(competitionId));
+
+  useEffect(() => {
+    fetchGroupData();
+  }, [id]);
+
+  useEffect(() => {
+    if (selectedCompId) {
+      fetchLeaderboard();
+    }
+  }, [selectedCompId]);
+
+  const fetchGroupData = async () => {
+    try {
+      const [groupRes, compsRes] = await Promise.all([
+        getGroup(id),
+        getGroupCompetitions(id),
+      ]);
+      setGroup(groupRes.data.group);
+      setCompetitions(compsRes.data.competitions || []);
+      if (compsRes.data.competitions?.length > 0 && !selectedCompId) {
+        setSelectedCompId(compsRes.data.competitions[0].id);
+      }
+    } catch (err) {
+      console.error('Failed to fetch group data:', err);
+    }
+  };
+
+  const fetchLeaderboard = async () => {
+    setIsLoading(true);
+    try {
+      const res = await getGroupLeaderboard(id, selectedCompId);
+      setLeaderboard(res.data.leaderboard || []);
+      const comp = res.data.competition;
+      if (comp && comp.id) {
+        setCompetition(comp);
+      }
+    } catch (err) {
+      console.error('Failed to fetch leaderboard:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getRankIcon = (rank) => {
+    if (rank === 1) return <Medal className="w-6 h-6 text-gold-500" />;
+    if (rank === 2) return <Medal className="w-6 h-6 text-slate-300" />;
+    if (rank === 3) return <Medal className="w-6 h-6 text-amber-600" />;
+    return <span className="text-slate-400 font-medium">#{rank}</span>;
+  };
+
+  const getRankBg = (rank) => {
+    if (rank === 1) return 'bg-gold-500/10 border-gold-500/30';
+    if (rank === 2) return 'bg-slate-500/10 border-slate-500/30';
+    if (rank === 3) return 'bg-amber-600/10 border-amber-600/30';
+    return 'bg-slate-800 border-slate-700';
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="flex items-center gap-3 mb-8">
+        <Link to={`/groups/${id}`} className="text-slate-400 hover:text-white transition-colors">
+          <ArrowLeft className="w-6 h-6" />
+        </Link>
+        <div>
+          <h1 className="text-xl font-bold text-white">
+            {competition?.name || '组排行榜'}
+          </h1>
+          {group && <p className="text-slate-400 text-sm">{group.name} - 组内排行</p>}
+        </div>
+      </div>
+
+      {/* Competition Selector */}
+      {competitions.length > 1 && (
+        <div className="mb-6">
+          <div className="flex flex-wrap gap-2">
+            {competitions.map((c) => (
+              <button
+                key={c.id}
+                onClick={() => setSelectedCompId(c.id)}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  selectedCompId === c.id
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-slate-800 text-slate-400 hover:bg-slate-700'
+                }`}
+              >
+                {c.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Leaderboard */}
+      {isLoading ? (
+        <div className="space-y-4">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="bg-slate-800 rounded-xl p-6 animate-pulse">
+              <div className="flex items-center gap-4">
+                <div className="w-10 h-10 bg-slate-700 rounded-full"></div>
+                <div className="flex-1">
+                  <div className="h-5 bg-slate-700 rounded w-1/3 mb-2"></div>
+                  <div className="h-4 bg-slate-700 rounded w-1/4"></div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : leaderboard.length === 0 ? (
+        <div className="text-center py-16">
+          <Trophy className="w-16 h-16 text-slate-600 mx-auto mb-4" />
+          <p className="text-slate-400 text-lg">暂无排行数据</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {leaderboard.map((entry) => (
+            <div
+              key={entry.user_id}
+              className={`flex items-center gap-4 p-4 rounded-xl border ${getRankBg(entry.rank)} ${
+                user?.id === entry.user_id ? 'ring-2 ring-blue-500' : ''
+              }`}
+            >
+              <div className="w-10 h-10 flex items-center justify-center">
+                {getRankIcon(entry.rank)}
+              </div>
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-white">{entry.username}</span>
+                  {entry.rank <= 3 && <span className="text-xs">🏆</span>}
+                  {user?.id === entry.user_id && (
+                    <span className="text-xs text-blue-400">(你)</span>
+                  )}
+                </div>
+                <div className="text-slate-400 text-sm flex items-center gap-3">
+                  <span>{entry.predictions_count} 次预测</span>
+                  <span>·</span>
+                  <span>{entry.exact_scores} 场全对</span>
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="text-2xl font-bold text-blue-400">{entry.total_points}</div>
+                <div className="text-slate-400 text-xs">总积分</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/GroupMembersPage.jsx
+++ b/frontend/src/pages/GroupMembersPage.jsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { getGroupMembers, getGroup } from '../api/apiClient';
+import { ArrowLeft, Crown, User } from 'lucide-react';
+import { useAuth } from '../context/AuthContext';
+
+export default function GroupMembersPage() {
+  const { id } = useParams();
+  const { user } = useAuth();
+  const [members, setMembers] = useState([]);
+  const [group, setGroup] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetchData();
+  }, [id]);
+
+  const fetchData = async () => {
+    setIsLoading(true);
+    try {
+      const [membersRes, groupRes] = await Promise.all([
+        getGroupMembers(id),
+        getGroup(id),
+      ]);
+      setMembers(membersRes.data.members || []);
+      setGroup(groupRes.data.group);
+    } catch (err) {
+      console.error('Failed to fetch members:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const isOwner = group?.owner_id === user?.id;
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-8">
+      <div className="flex items-center gap-3 mb-8">
+        <Link to={`/groups/${id}`} className="text-slate-400 hover:text-white transition-colors">
+          <ArrowLeft className="w-6 h-6" />
+        </Link>
+        <h1 className="text-xl font-bold text-white">组成员</h1>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-slate-800 rounded-xl p-4 animate-pulse">
+              <div className="h-5 bg-slate-700 rounded w-1/3"></div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {members.map((member) => (
+            <div
+              key={member.user_id}
+              className="flex items-center gap-3 bg-slate-800 border border-slate-700 rounded-xl p-4"
+            >
+              <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
+                member.role === 'admin' ? 'bg-gold-600' : 'bg-slate-600'
+              }`}>
+                {member.role === 'admin' ? (
+                  <Crown className="w-5 h-5 text-white" />
+                ) : (
+                  <User className="w-5 h-5 text-white" />
+                )}
+              </div>
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-white">{member.username}</span>
+                  {member.role === 'admin' && (
+                    <span className="text-xs bg-gold-600/20 text-gold-400 px-2 py-0.5 rounded">
+                      {member.user_id === group?.owner_id ? '组长' : '管理员'}
+                    </span>
+                  )}
+                </div>
+                <p className="text-slate-400 text-xs">
+                  加入于 {new Date(member.joined_at).toLocaleDateString('zh-CN')}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/JoinGroupPage.jsx
+++ b/frontend/src/pages/JoinGroupPage.jsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { joinGroup } from '../api/apiClient';
+import { ArrowLeft } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+export default function JoinGroupPage() {
+  const navigate = useNavigate();
+  const [inviteCode, setInviteCode] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!inviteCode.trim() || inviteCode.trim().length !== 6) {
+      setError('请输入6位邀请码');
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+    try {
+      const res = await joinGroup(inviteCode.trim().toUpperCase());
+      navigate(`/groups/${res.data.group.id}`);
+    } catch (err) {
+      const msg = err.response?.data?.error;
+      if (msg === '邀请码无效') {
+        setError('邀请码无效，请检查后重新输入');
+      } else if (msg === '你已经在该组中') {
+        setError('你已经在该组中');
+      } else {
+        setError('加入失败，请重试');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-8">
+      <div className="flex items-center gap-3 mb-8">
+        <Link to="/groups" className="text-slate-400 hover:text-white transition-colors">
+          <ArrowLeft className="w-6 h-6" />
+        </Link>
+        <h1 className="text-xl font-bold text-white">加入组</h1>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div>
+          <label className="block text-slate-300 text-sm font-medium mb-2">邀请码</label>
+          <input
+            type="text"
+            value={inviteCode}
+            onChange={(e) => setInviteCode(e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, ''))}
+            placeholder="6位字母或数字"
+            maxLength={6}
+            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-3 text-white text-center text-2xl tracking-widest placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors font-mono"
+            autoFocus
+          />
+          {error && <p className="mt-2 text-red-400 text-sm text-center">{error}</p>}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isLoading || inviteCode.length !== 6}
+          className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-slate-700 disabled:text-slate-500 text-white font-medium py-3 rounded-lg transition-colors"
+        >
+          {isLoading ? '加入中...' : '加入组'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/MyGroupsPage.jsx
+++ b/frontend/src/pages/MyGroupsPage.jsx
@@ -1,0 +1,129 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { getMyGroups } from '../api/apiClient';
+import { Users, Plus, Trophy, Crown } from 'lucide-react';
+
+export default function MyGroupsPage() {
+  const [groups, setGroups] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetchGroups();
+  }, []);
+
+  const fetchGroups = async () => {
+    setIsLoading(true);
+    try {
+      const res = await getMyGroups();
+      setGroups(res.data.groups || []);
+    } catch (err) {
+      console.error('Failed to fetch groups:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="flex items-center justify-between mb-8">
+        <div className="flex items-center gap-3">
+          <div className="w-12 h-12 bg-blue-600 rounded-xl flex items-center justify-center">
+            <Users className="w-6 h-6 text-white" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-white">我的组</h1>
+            <p className="text-slate-400 text-sm">和好友一起竞猜排行</p>
+          </div>
+        </div>
+        <div className="flex gap-3">
+          <Link
+            to="/groups/join"
+            className="flex items-center gap-2 bg-slate-700 hover:bg-slate-600 text-white px-4 py-2 rounded-lg transition-colors"
+          >
+            加入组
+          </Link>
+          <Link
+            to="/groups/new"
+            className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            创建组
+          </Link>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-slate-800 rounded-xl p-6 animate-pulse">
+              <div className="h-6 bg-slate-700 rounded w-1/3 mb-3"></div>
+              <div className="h-4 bg-slate-700 rounded w-1/4"></div>
+            </div>
+          ))}
+        </div>
+      ) : groups.length === 0 ? (
+        <div className="text-center py-20">
+          <Users className="w-20 h-20 text-slate-600 mx-auto mb-4" />
+          <p className="text-slate-400 text-lg mb-2">你还没有加入任何组</p>
+          <p className="text-slate-500 text-sm mb-6">创建或加入组，和朋友一起比拼预测实力</p>
+          <div className="flex justify-center gap-4">
+            <Link
+              to="/groups/join"
+              className="bg-slate-700 hover:bg-slate-600 text-white px-6 py-2 rounded-lg transition-colors"
+            >
+              加入组
+            </Link>
+            <Link
+              to="/groups/new"
+              className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors"
+            >
+              创建组
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {groups.map((group) => (
+            <Link
+              key={group.id}
+              to={`/groups/${group.id}`}
+              className="block bg-slate-800 border border-slate-700 hover:border-slate-600 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${
+                    group.role === 'admin' ? 'bg-gold-600' : 'bg-blue-600'
+                  }`}>
+                    {group.role === 'admin' ? (
+                      <Crown className="w-6 h-6 text-white" />
+                    ) : (
+                      <Users className="w-6 h-6 text-white" />
+                    )}
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <h3 className="font-semibold text-white">{group.name}</h3>
+                      {group.role === 'admin' && (
+                        <span className="text-xs bg-gold-600/20 text-gold-400 px-2 py-0.5 rounded">组长</span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-4 text-slate-400 text-sm">
+                      <span>{group.member_count} 名成员</span>
+                      <span className="text-slate-600">·</span>
+                      <span>{group.competition_count} 个追踪赛事</span>
+                    </div>
+                  </div>
+                </div>
+                <div className="text-slate-500">
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- MyGroupsPage: list of user's groups with create/join actions
- CreateGroupPage: form to create a new group
- JoinGroupPage: form to join a group by invite code
- GroupDetailPage: group info, tracked competitions, actions
- GroupMembersPage: member list with roles
- GroupLeaderboardPage: group competition leaderboard
- AddGroupCompetitionPage: admin adds competitions to track
- Update Navbar: add '我的组' link
- Update App.jsx: add all group routes (protected)