### PR TITLE
fix: allow 0 as valid prediction score

### DIFF
--- a/handlers/prediction_handler.go
+++ b/handlers/prediction_handler.go
@@ -35,8 +35,8 @@ func (h *PredictionHandler) CreatePrediction(c *gin.Context) {
 	prediction, err := h.predictionService.CreatePrediction(
 		userID.(uint),
 		req.MatchID,
-		req.PredictedHomeScore,
-		req.PredictedAwayScore,
+		*req.PredictedHomeScore,
+		*req.PredictedAwayScore,
 	)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -73,8 +73,8 @@ func (h *PredictionHandler) UpdatePrediction(c *gin.Context) {
 	prediction, err := h.predictionService.UpdatePrediction(
 		uint(id),
 		userID.(uint),
-		req.PredictedHomeScore,
-		req.PredictedAwayScore,
+		*req.PredictedHomeScore,
+		*req.PredictedAwayScore,
 	)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/models/prediction.go
+++ b/models/prediction.go
@@ -22,8 +22,8 @@ type Prediction struct {
 
 type PredictionRequest struct {
 	MatchID            uint `json:"match_id" binding:"required"`
-	PredictedHomeScore int  `json:"predicted_home_score" binding:"required,min=0"`
-	PredictedAwayScore int  `json:"predicted_away_score" binding:"required,min=0"`
+	PredictedHomeScore *int `json:"predicted_home_score" binding:"required,min=0"`
+	PredictedAwayScore *int `json:"predicted_away_score" binding:"required,min=0"`
 }
 
 type PredictionResponse struct {

--- a/models/prediction_test.go
+++ b/models/prediction_test.go
@@ -8,15 +8,17 @@ import (
 )
 
 func TestPredictionRequest_Fields(t *testing.T) {
+	home := 2
+	away := 1
 	req := PredictionRequest{
 		MatchID:            10,
-		PredictedHomeScore: 2,
-		PredictedAwayScore: 1,
+		PredictedHomeScore: &home,
+		PredictedAwayScore: &away,
 	}
 
 	assert.Equal(t, uint(10), req.MatchID)
-	assert.Equal(t, 2, req.PredictedHomeScore)
-	assert.Equal(t, 1, req.PredictedAwayScore)
+	assert.Equal(t, 2, *req.PredictedHomeScore)
+	assert.Equal(t, 1, *req.PredictedAwayScore)
 }
 
 func TestPredictionResponse_Fields(t *testing.T) {


### PR DESCRIPTION
PredictionRequest used 'required' on int fields, but Go's Gin treats 0 as the zero-value and fails validation. Changed PredictedHomeScore and PredictedAwayScore to *int so that 0 is a valid input instead of being treated as missing.