### PR TITLE
fix: 修复多个bug并完善文档

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,10 @@ footballPaul/
 
 **认证**: 基于 JWT（`middleware/auth.go`）。受保护的路由使用 `middleware.AuthMiddleware(cfg)`。
 
+**API 认证路由**:
+- `POST /api/auth/register` - 注册用户（需提供 username, email, password）
+- `POST /api/auth/login` - 登录获取 JWT token（需提供 email, password）
+
 **配置**: 通过 `config/config.go` 读取环境变量 - DB_DSN（数据库路径）, SERVER_PORT, JWT_SECRET。
 
 ## 测试

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ FootballPaul 是一个交互式的足球比赛预测平台，用户可以：
 | 完全正确 | 10分 | 比分完全一致 | 预测2:1，实际2:1 |
 | 猜中胜负+净胜球 | 7分 | 结果和净胜球都正确 | 预测2:0，实际3:1（净胜2球） |
 | 猜中胜负 | 5分 | 只猜中胜/平/负 | 预测2:1，实际3:2（都是主胜） |
-| 猜中一方得分 | 3分 | 猜中任一队伍得分 | 预测2:1，实际2:3（主队得2分） |
+| 猜中一方得分 | 3分 | 预测结果错误，但某队比分猜对 | 预测2:1，实际2:3（主队得分相同，但结果主队输） |
 | 其他 | 0分 | 预测不准确 | - |
 
 ### 评分逻辑示例
@@ -190,6 +190,44 @@ footballPaul/
 - 个人数据分析
 
 ## 📡 API 接口
+
+### 用户认证接口
+
+**注册用户**
+```http
+POST /api/auth/register
+Content-Type: application/json
+
+{
+  "username": "player1",
+  "email": "player1@example.com",
+  "password": "password123"
+}
+
+Response:
+{
+  "success": true,
+  "user": {"id": 1, "username": "player1", "email": "player1@example.com", "total_points": 0}
+}
+```
+
+**登录**
+```http
+POST /api/auth/login
+Content-Type: application/json
+
+{
+  "email": "player1@example.com",
+  "password": "password123"
+}
+
+Response:
+{
+  "success": true,
+  "token": "eyJhbGc...",
+  "user": {"id": 1, "username": "player1", "email": "player1@example.com", "total_points": 0}
+}
+```
 
 ### 用户预测接口
 

--- a/handlers/prediction_handler.go
+++ b/handlers/prediction_handler.go
@@ -43,10 +43,13 @@ func (h *PredictionHandler) CreatePrediction(c *gin.Context) {
 		return
 	}
 
+	// 重新查询以获取完整关联数据
+	prediction, _ = h.predictionService.GetPredictionByID(prediction.ID)
+
 	c.JSON(http.StatusCreated, gin.H{
-		"success":       true,
-		"prediction_id": prediction.ID,
-		"message":       "预测提交成功",
+		"success":    true,
+		"prediction": prediction,
+		"message":    "预测提交成功",
 	})
 }
 
@@ -80,6 +83,15 @@ func (h *PredictionHandler) UpdatePrediction(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+
+	// 验证请求中的 match_id 与预测记录一致（防止误传数据）
+	if req.MatchID > 0 && prediction.MatchID != req.MatchID {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "match_id mismatch"})
+		return
+	}
+
+	// 重新查询以获取完整关联数据（User、Match、Competition）
+	prediction, _ = h.predictionService.GetPredictionByID(prediction.ID)
 
 	c.JSON(http.StatusOK, gin.H{
 		"success":    true,
@@ -118,7 +130,8 @@ func (h *PredictionHandler) GetMatchPredictions(c *gin.Context) {
 		return
 	}
 
-	predictions, err := h.predictionService.GetMatchPredictions(uint(matchID), false)
+	// 需要同时加载 User 和 Match+Competition 信息
+	predictions, err := h.predictionService.GetMatchPredictionsWithUsers(uint(matchID))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/models/match.go
+++ b/models/match.go
@@ -2,13 +2,15 @@ package models
 
 import (
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type MatchStatus string
 
 const (
 	MatchStatusPending  MatchStatus = "pending"
-	MatchStatusOngoing  MatchStatus = "ongoing"
+	MatchStatusOngoing MatchStatus = "ongoing"
 	MatchStatusFinished MatchStatus = "finished"
 )
 
@@ -32,4 +34,10 @@ type Match struct {
 type MatchResult struct {
 	HomeScore int `json:"home_score" binding:"required,min=0"`
 	AwayScore int `json:"away_score" binding:"required,min=0"`
+}
+
+// AfterCreate 创建比赛后自动更新赛事的 match_count
+func (m *Match) AfterCreate(tx *gorm.DB) error {
+	return tx.Model(&Competition{}).Where("id = ?", m.CompetitionID).
+		UpdateColumn("match_count", gorm.Expr("match_count + 1")).Error
 }

--- a/services/leaderboard_service.go
+++ b/services/leaderboard_service.go
@@ -24,7 +24,7 @@ func (s *LeaderboardService) GetLeaderboard(competitionID uint, limit int) ([]Le
 		UserID           uint  `gorm:"column:id"`
 		Username         string `gorm:"column:username"`
 		TotalPoints      int    `gorm:"column:total_points"`
-		PredictionsCount  int64  `gorm:"column:predictions_count"`
+		PredictionsCount int64  `gorm:"column:predictions_count"`
 	}
 
 	var results []userWithStats
@@ -34,13 +34,14 @@ func (s *LeaderboardService) GetLeaderboard(competitionID uint, limit int) ([]Le
 		subQuery := database.DB.Model(&models.Prediction{}).
 			Select("predictions.user_id, COUNT(*) as predictions_count, COALESCE(SUM(predictions.points_earned), 0) as total_points").
 			Joins("JOIN matches ON predictions.match_id = matches.id").
-			Where("matches.competition_id = ? AND predictions.is_scored = ?", competitionID, true).
+			Where("matches.competition_id = ?", competitionID).
 			Group("predictions.user_id")
 
+		// 使用 LEFT JOIN 确保显示所有有预测的用户，即使没有被评分的预测也显示
 		query := database.DB.Table("users").
 			Select("users.id, users.username, COALESCE(sq.total_points, 0) as total_points, COALESCE(sq.predictions_count, 0) as predictions_count").
 			Joins("LEFT JOIN (?) as sq ON users.id = sq.user_id", subQuery).
-			Where("sq.predictions_count > 0").
+			Where("COALESCE(sq.predictions_count, 0) > 0").
 			Order("sq.total_points DESC, users.id ASC")
 
 		if limit > 0 {
@@ -54,13 +55,13 @@ func (s *LeaderboardService) GetLeaderboard(competitionID uint, limit int) ([]Le
 		// Global leaderboard (all predictions)
 		subQuery := database.DB.Model(&models.Prediction{}).
 			Select("user_id, COUNT(*) as predictions_count, COALESCE(SUM(points_earned), 0) as total_points").
-			Where("is_scored = ?", true).
 			Group("user_id")
 
+		// 使用 LEFT JOIN + COALESCE 确保显示所有有预测的用户
 		query := database.DB.Table("users").
 			Select("users.id, users.username, COALESCE(sq.total_points, 0) as total_points, COALESCE(sq.predictions_count, 0) as predictions_count").
 			Joins("LEFT JOIN (?) as sq ON users.id = sq.user_id", subQuery).
-			Where("sq.predictions_count > 0").
+			Where("COALESCE(sq.predictions_count, 0) > 0").
 			Order("sq.total_points DESC, users.id ASC")
 
 		if limit > 0 {
@@ -99,7 +100,7 @@ func (s *LeaderboardService) GetUserRank(userID uint, competitionID uint) (int, 
 		subQuery := database.DB.Model(&models.Prediction{}).
 			Select("user_id, COALESCE(SUM(points_earned), 0) as total_points").
 			Joins("JOIN matches ON predictions.match_id = matches.id").
-			Where("matches.competition_id = ? AND predictions.is_scored = ?", competitionID, true).
+			Where("matches.competition_id = ?", competitionID).
 			Group("predictions.user_id").
 			Having("user_id = ?", userID)
 
@@ -116,7 +117,7 @@ func (s *LeaderboardService) GetUserRank(userID uint, competitionID uint) (int, 
 		subQueryHigher := database.DB.Model(&models.Prediction{}).
 			Select("user_id, COALESCE(SUM(points_earned), 0) as total_points").
 			Joins("JOIN matches ON predictions.match_id = matches.id").
-			Where("matches.competition_id = ? AND predictions.is_scored = ?", competitionID, true).
+			Where("matches.competition_id = ?", competitionID).
 			Group("predictions.user_id").
 			Having("COALESCE(SUM(points_earned), 0) > ?", currentUser.TotalPoints)
 
@@ -132,7 +133,7 @@ func (s *LeaderboardService) GetUserRank(userID uint, competitionID uint) (int, 
 		// Global rank
 		if err := database.DB.Table("users").
 			Select("users.id, COALESCE(sq.total_points, 0) as total_points").
-			Joins("LEFT JOIN (SELECT user_id, COALESCE(SUM(points_earned), 0) as total_points FROM predictions WHERE is_scored = true GROUP BY user_id) as sq ON users.id = sq.user_id").
+			Joins("LEFT JOIN (SELECT user_id, COALESCE(SUM(points_earned), 0) as total_points FROM predictions GROUP BY user_id) as sq ON users.id = sq.user_id").
 			Where("users.id = ?", userID).
 			Scan(&currentUser).Error; err != nil {
 			return 0, err
@@ -140,7 +141,7 @@ func (s *LeaderboardService) GetUserRank(userID uint, competitionID uint) (int, 
 
 		var rank int64
 		if err := database.DB.Model(&models.User{}).
-			Joins("LEFT JOIN (SELECT user_id, COALESCE(SUM(points_earned), 0) as total_points FROM predictions WHERE is_scored = true GROUP BY user_id) as sq ON users.id = sq.user_id").
+			Joins("LEFT JOIN (SELECT user_id, COALESCE(SUM(points_earned), 0) as total_points FROM predictions GROUP BY user_id) as sq ON users.id = sq.user_id").
 			Where("COALESCE(sq.total_points, 0) > ?", currentUser.TotalPoints).
 			Count(&rank).Error; err != nil {
 			return 0, err
@@ -161,7 +162,7 @@ func (s *LeaderboardService) GetUserPointsByCompetition(userID uint) (map[uint]i
 	if err := database.DB.Model(&models.Prediction{}).
 		Select("matches.competition_id, COALESCE(SUM(predictions.points_earned), 0) as total_points").
 		Joins("JOIN matches ON predictions.match_id = matches.id").
-		Where("predictions.user_id = ? AND predictions.is_scored = ?", userID, true).
+		Where("predictions.user_id = ?", userID).
 		Group("matches.competition_id").
 		Scan(&results).Error; err != nil {
 		return nil, err

--- a/services/prediction_service.go
+++ b/services/prediction_service.go
@@ -123,9 +123,23 @@ func (s *PredictionService) GetMatchPredictions(matchID uint, includeUser bool) 
 	return predictions, nil
 }
 
+// GetMatchPredictionsWithUsers 查询比赛的所有预测，并加载用户和比赛信息
+func (s *PredictionService) GetMatchPredictionsWithUsers(matchID uint) ([]models.Prediction, error) {
+	var predictions []models.Prediction
+	result := database.DB.Where("match_id = ?", matchID).
+		Preload("User").
+		Preload("Match").
+		Preload("Match.Competition").
+		Find(&predictions)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return predictions, nil
+}
+
 func (s *PredictionService) GetPredictionByID(id uint) (*models.Prediction, error) {
 	var prediction models.Prediction
-	result := database.DB.Preload("Match").Preload("User").First(&prediction, id)
+	result := database.DB.Preload("User").Preload("Match").Preload("Match.Competition").First(&prediction, id)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, errors.New("prediction not found")


### PR DESCRIPTION
## 修复内容

### Bug 修复
- **match_count 始终为 0**: 在 Match model 添加 AfterCreate hook，创建比赛时自动递增赛事下的比赛数量
- **预测响应中 User/Match 关联为空**: `GetMatchPredictions` 改用新的 `GetMatchPredictionsWithUsers` 方法，完整预加载 User、Match、Competition 关联
- **UpdatePrediction 返回空关联**: 保存后重新调用 `GetPredictionByID` 获取完整的关联数据
- **CreatePrediction 统一返回带完整关联的 prediction 对象**

### 排行榜改进
- **移除 is_scored=true 过滤条件**: 排行榜现在显示所有有预测记录的用户（包括尚未评分的 0 分用户）
- **COALESCE 配合 LEFT JOIN**: 确保未评分预测也正确计入统计

### API 文档修复
- **补充缺失的用户认证 API**: 在 README.md 中添加 `POST /api/auth/register` 和 `POST /api/auth/login` 的完整示例
- **更新 CLAUDE.md**: 添加认证路由说明

### 积分规则描述修正
- **修正「猜中一方得分」规则歧义**: 原描述「猜中任一队伍得分」容易误解，新描述明确指出「预测结果错误，但某队比分猜对」

### 其他改进
- **UpdatePrediction 添加 match_id 校验**: 防止请求中 match_id 与实际预测记录不匹配

---

**测试**: 所有原有测试通过 (`go test ./...`)