### PR TITLE
fix: allow 0 as valid match result score

### DIFF
--- a/models/match.go
+++ b/models/match.go
@@ -32,8 +32,8 @@ type Match struct {
 }
 
 type MatchResult struct {
-	HomeScore int `json:"home_score" binding:"required,min=0"`
-	AwayScore int `json:"away_score" binding:"required,min=0"`
+	HomeScore int `json:"home_score" binding:"min=0"`
+	AwayScore int `json:"away_score" binding:"min=0"`
 }
 
 // EffectiveStatus 根据当前时间和比分录入情况，动态计算比赛状态


### PR DESCRIPTION
Remove 'required' validation from MatchResult.HomeScore and AwayScore to fix the issue where entering 0 as score would cause a validation error. The 'min=0' constraint is preserved, so 0 is now correctly accepted.